### PR TITLE
Simplify interface and improve coxeter interoperability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,66 @@
-<img src="https://prideout.net/blog/svg_wireframes/filmstrip.svg" width="512px">
+This is a single-file Python library for generating 3D wireframes in SVG format. We aim to create a framwork for rendering shapes (and arrays of shapes) as vector graphics in a performant and pythonic way. This code is adapted from [the original svg3d](https://github.com/prideout/svg3d) for compatibility with [coxeter](https://github.com/glotzerlab/coxeter) and to simplify the interface.
 
-This is a ~~single-file Python library~~ _pip-installable Python package_ for generating 3D wireframes in SVG format. _We aim to create a framwork for rendering shapes (and arrays of shapes) as vector graphics in a performant and pythonic way._
 
-### Short-term goals to extend prideout/svg3d
-
-- Simplify the rendering of single shapes to focus on a fixed viewpoint and movable/scalable/rotatable polyhedron objects
-
-### Longer-term goals
-- Create code to render arrays of shapes (such as outputs from molecular dynamics simulations, quasicrystal tilings, or dense packings)
-- Create interactive viewports that can be run in jupyter notebooks and controlled through a gui by the end user
-
-For a description of how the library was designed and implemented, check out
+For a description of how the library was initially designed and implemented, check out
 [this blog post](https://prideout.net/blog/svg_wireframes/#using-the-api).
 
 ## Usage example (ConvexPolyhedron)
 ```python
-def generate_svg_from_polyhedron(poly, filename):
-    def pad_arrays(arrays):
-        # Find the length of the longest array
-        max_length = max(len(arr) for arr in arrays)
+from coxeter.families import ArchimedeanFamily
 
-        # Pad each array to the length of the longest array
-        padded_array = [
-            np.append(arr, [arr[0]] * (max_length - len(arr))) for arr in arrays
-        ]
-        return np.array(padded_array, dtype=int)
+import svg3d
+from svg3d import get_lookat_matrix, get_projection_matrix
 
-    arr = poly.vertices[pad_arrays(poly.faces)]
 
-    view = pyrr.matrix44.create_look_at(
-        eye=[50, 40, 120],
-        target=[0, 0, 0],
-        up=[0, 1, 0]
-        # eye=[50, 40, 120], target=[0, 0, 0], up=[0, 1, 0]
-    )
-    projection = pyrr.matrix44.create_perspective_projection(
-        # fovy=15, aspect=1, near=10, far=200
-        fovy=3,
-        aspect=1,
-        near=10,
-        far=200,
-    )
-    camera = svg3d.Camera(view, projection)
+def generate_svg(filename, poly):
+    pos_object = [0.0, 0.0, 0.0]  # "at" position
+    pos_camera = [40, 40, 120]  # "eye" position
+    vec_up = [0.0, 1.0, 0.0]  # "up" vector of camera. This is the default value.
 
-    style = dict(
-        fill="#FFCB05",
-        fill_opacity="1",
-        stroke="black",
-        stroke_linejoin="round",
-        stroke_width="0.002",
+    z_near, z_far = 1.0, 200.0
+    aspect = 1.0  # Aspect ratio of the view cone
+    fov_y = 1.0  # Opening angle of the view cone. fov_x is equal to fov_y * aspect
+
+    look_at = get_lookat_matrix(pos_object, pos_camera, vec_up=vec_up)
+    projection = get_projection_matrix(
+        z_near=z_near, z_far=z_far, fov_y=fov_y, aspect=aspect
     )
 
-    mesh = svg3d.Mesh(arr, style=style)
-    view = svg3d.View(camera, svg3d.Scene([mesh]))
+    # A "scene" is a list of Mesh objects, which can be easily generated from Coxeter!
+    scene = [svg3d.Mesh.from_poly(poly, style=style)]
+
+    view = svg3d.View.from_look_at_and_projection(
+        look_at=look_at,
+        projection=projection,
+        scene=scene,
+    )
+
     svg3d.Engine([view]).render(filename)
+
+
+style = dict(
+    fill="#00B2A6",
+    fill_opacity="0.85",
+    stroke="black",
+    stroke_linejoin="round",
+    stroke_width="0.005",
+)
+
+truncated_cube = ArchimedeanFamily.get_shape("Truncated Cube")
+generate_svg(filename="truncated_cube.svg", poly=truncated_cube)
 ```
 
-_Note the above method is imperfect - it pads faces to all eb the same length, adding many extra strokes to the resulting SVG._
+And that's all it takes! For an even simpler startup, use one of the built in viewports.
 
-
-## Usage example (default)
+For example:
 
 ```python
-import numpy, svg3d, pyrr, math
+import svg3d
 
-def get_octahedron_faces():
-    f = math.sqrt(2.0) / 2.0
-    verts = numpy.float32([ ( 0, -1,  0), (-f,  0,  f), ( f,  0,  f), ( f,  0, -f), (-f,  0, -f), ( 0,  1,  0) ])
-    triangles = numpy.int32([ (0, 2, 1), (0, 3, 2), (0, 4, 3), (0, 1, 4), (5, 1, 2), (5, 2, 3), (5, 3, 4), (5, 4, 1) ])
-    return 15.0 * verts[triangles]
+scene = [svg3d.Mesh.from_poly(poly, style=style)]
 
-def generate_svg(filename):
-    view = pyrr.matrix44.create_look_at(eye=[50, 40, 120], target=[0, 0, 0], up=[0, 1, 0])
-    projection = pyrr.matrix44.create_perspective_projection(fovy=15, aspect=1, near=10, far=200)
-    camera = svg3d.Camera(view, projection)
+iso = svg3d.View.isometric(scene, fov=1.0)
+dim = svg3d.View.dimetric(scene, fov=1.0)
+tri = svg3d.View.trimetric(scene, fov=1.0)
 
-    style = dict(
-        fill="white", fill_opacity="0.75",
-        stroke="black", stroke_linejoin="round", stroke_width="0.005")
-
-    mesh = svg3d.Mesh(get_octahedron_faces(), style=style)
-    view = svg3d.View(camera, svg3d.Scene([mesh]))
-    svg3d.Engine([view]).render(filename)
-
-generate_svg("octahedron.svg")
-```
-
-The above code snippet generates an image like this:
-
-<img src="https://prideout.net/blog/svg_wireframes/octahedron.svg" width="256px">
-
-## Running the test script
-
-```
-pipenv shell
-pipenv install
-cd extras
-./test.py && open gallery.html
 ```

--- a/svg3d.py
+++ b/svg3d.py
@@ -160,17 +160,34 @@ class View(NamedTuple):
         look_at: np.ndarray,
         projection: np.ndarray,
         scene: tuple[Mesh],
-        viewport: Viewport | None = None,
     ):
         assert look_at.shape == (4, 4) and projection.shape == (4, 4)
         return cls(
-            look_at, projection, scene, viewport if viewport is not None else Viewport()
+            look_at,
+            projection,
+            scene,
         )
 
     @classmethod
     def isometric(cls, scene, fov: float = 1.0):
         return cls(
             look_at=get_lookat_matrix(pos_object=[0, 0, 0], pos_camera=[100, 100, 100]),
+            projection=get_projection_matrix(z_near=1.0, z_far=200.0, fov_y=fov),
+            scene=scene,
+        )
+
+    @classmethod
+    def dimetric(cls, scene, fov: float = 1.0):
+        return cls(
+            look_at=get_lookat_matrix(pos_object=[0, 0, 0], pos_camera=[40, 40, 105]),
+            projection=get_projection_matrix(z_near=1.0, z_far=200.0, fov_y=fov),
+            scene=scene,
+        )
+
+    @classmethod
+    def trimetric(cls, scene, fov: float = 1.0):
+        return cls(
+            look_at=get_lookat_matrix(pos_object=[0, 0, 0], pos_camera=[80, 40, 120]),
             projection=get_projection_matrix(z_near=1.0, z_far=200.0, fov_y=fov),
             scene=scene,
         )

--- a/svg3d.py
+++ b/svg3d.py
@@ -129,15 +129,35 @@ class Viewport(NamedTuple):
         return cls(*args)
 
 
-class Mesh(NamedTuple):
-    poly: "coxeter.shapes.ConvexPolyhedron" = None
-    shader: Callable[[int, float], dict] = None
-    style: dict = None
-    circle_radius: float = 0
+class Mesh:
+    def __init__(
+        self,
+        poly: "coxeter.shapes.ConvexPolyhedron" | None = None,
+        shader: Callable[[int, float], dict] | None = None,
+        style: dict | None = None,
+        circle_radius: float = 0.0,
+    ):
+        self.poly = poly
+        self.shader = shader
+        self.style = style
+        self.circle_radius = circle_radius
+        self._faces = None
 
     @property
     def faces(self):
-        return self.poly.vertices[_pad_arrays(self.poly.faces)]
+        if self._faces is None:
+            if self.poly is None:
+                msg = (
+                    "Faces cannot be automatically generated without setting `poly`."
+                    "Set `faces` or `poly` before continuing!"
+                )
+                raise KeyError(msg)
+            self._faces = self.poly.vertices[_pad_arrays(self.poly.faces)]
+        return self._faces
+
+    @faces.setter
+    def faces(self, faces):
+        self._faces = faces
 
     @property
     def centroid(self):
@@ -146,6 +166,12 @@ class Mesh(NamedTuple):
     @classmethod
     def from_poly(cls, poly, shader=None, style=None):
         return cls(poly=poly, shader=shader, style=style)
+
+    @classmethod
+    def from_faces(cls, faces, shader=None, style=None):
+        new = cls(poly=None, shader=shader, style=style)
+        new.faces = faces
+        return new
 
 
 class View(NamedTuple):

--- a/svg3d.py
+++ b/svg3d.py
@@ -1,13 +1,116 @@
 # svg3d :: https://prideout.net/blog/svg_wireframes/
 # Single-file Python library for generating 3D wireframes in SVG format.
-# Copyright (c) 2019 Philip Rideout
+# Adapted from https://prideout.net/blog/svg_wireframes/
+# Copyright (c) 2019 Philip Rideout. Modified 2024 by Jenna Bradley.
 # Distributed under the MIT License, see bottom of file.
 
+
+import math
+from typing import Callable, NamedTuple
+
 import numpy as np
-import pyrr
 import svgwrite
 
-from typing import NamedTuple, Callable, Sequence
+
+def _pad_arrays(arrays):
+    # Find the length of the longest array
+    max_length = max(len(arr) for arr in arrays)
+
+    # Pad each array to the length of the longest array
+    padded_array = [
+        np.append(arr, [arr[0]] * (max_length - len(arr))) for arr in arrays
+    ]
+    return np.array(padded_array, dtype=int)
+
+
+def get_lookat_matrix(
+    pos_object: np.ndarray,
+    pos_camera: np.ndarray,
+    vec_up: np.ndarray | tuple = (0.0, 1.0, 0.0),
+):
+    """Get the "look at" or view matrix for our system.
+
+    This matrix moves the world such that the camera is at the origin and rotates the
+    world such that the z-axis of the camera is the mathematical z axis.
+
+
+    Args:
+        pos_object (np.ndarray):
+          (N,3) position of the object we are looking at. "at" in openGL vernacular.
+        pos_camera (np.ndarray):
+          (N,3) position of the camera. "eye" in openGL vernacular.
+        vec_up (np.ndarray | tuple, optional):
+          (N,3) vector describing the height of the camera. "up" in openGL vernacular.
+          Default value: (0,1,0)
+
+    .. seealso:
+
+        https://stackoverflow.com/questions/349050/calculating-a-lookat-matrix/6802424#6802424
+
+    .. seealso:
+
+        https://medium.com/@carmencincotti/lets-look-at-magic-lookat-matrices-c77e53ebdf78
+
+    """
+    # First, shift the world such that the camera is at the origin
+    m_camera_translate = np.eye(4)
+    m_camera_translate[-1, :3] -= pos_camera
+
+    # Now, rotate the vector from the camera position to the object position such that it
+    # lines up with the z axis.
+
+    # Compute the x axis of our original coordinate system, along the vector camera - pos
+    axis_z = np.asarray(pos_camera, dtype=np.float64) - pos_object
+    axis_z /= np.linalg.norm(axis_z)  # "forward" axis in openGL terms
+
+    # Compute the y ("forward") axis of our original coordinate system. This is
+    # perpendicular to axis_z and any arbitrary vector in the plane formed by z and y
+    axis_x = np.cross(vec_up, axis_z)
+    axis_x /= np.linalg.norm(axis_x)  # "right" axis in openGL terms
+
+    axis_y = np.cross(axis_z, axis_x)  # "up" axis in openGL terms
+
+    m_camera_rotate = np.eye(4)
+    m_camera_rotate[:3, :3] = [axis_x, axis_y, axis_z]
+
+    return m_camera_translate @ (m_camera_rotate.T)
+
+
+def get_projection_matrix(
+    z_near: float, z_far: float, fov_y: float, aspect: float = 1.0
+):
+    """Get a projection matrix from frustum parameters.
+
+    z_near and z_far are the distances to the tip and base of the frustum, respectively.
+    fov_y describes the opening angle of the base, and aspect describes the relationship
+    between the y opening angle and the x.
+
+    Args:
+        z_near (float): Distance to the near clipping plane. Must be greater than zero.
+        z_far (float): Distance to the far clipping plane. Must be greater than z_near.
+        fov_y (float): Field of view angle along the y direction, in degrees.
+        aspect (float, optional):
+          Ratio of field of view angle in the y direction to field of view angle in x.
+          Default value: 1.0
+
+    .. seealso:
+
+        https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml
+
+    .. seealso:
+
+        http://www.songho.ca/opengl/gl_projectionmatrix.html
+
+    """
+    f = 1 / math.tan(math.radians(fov_y) / 2)
+    m_projection = np.zeros([4, 4])
+
+    m_projection[[0, 1, -1], [0, 1, 2]] = f / aspect, f, -1
+    m_projection[2, [2, 3]] = (
+        (z_near + z_far) / (z_near - z_far),
+        (2 * z_near * z_far) / (z_near - z_far),
+    )
+    return m_projection.T
 
 
 class Viewport(NamedTuple):
@@ -21,59 +124,86 @@ class Viewport(NamedTuple):
         return cls(-aspect_ratio / 2.0, -0.5, aspect_ratio, 1.0)
 
     @classmethod
-    def from_string(cls, string_to_parse):
+    def from_string(cls, string_to_parse: str):
         args = [float(f) for f in string_to_parse.split()]
         return cls(*args)
 
 
-class Camera(NamedTuple):
-    view: np.ndarray
-    projection: np.ndarray
-
-
 class Mesh(NamedTuple):
-    faces: np.ndarray
+    poly: "coxeter.shapes.ConvexPolyhedron" = None
     shader: Callable[[int, float], dict] = None
     style: dict = None
     circle_radius: float = 0
 
+    @property
+    def faces(self):
+        return self.poly.vertices[_pad_arrays(self.poly.faces)]
 
-class Scene(NamedTuple):
-    meshes: Sequence[Mesh]
+    @property
+    def centroid(self):
+        return self.poly.centroid if self.poly is not None else (0, 0, 0)
 
-    def add_mesh(self, mesh: Mesh):
-        self.meshes.append(mesh)
+    @classmethod
+    def from_poly(cls, poly, shader=None, style=None):
+        return cls(poly=poly, shader=shader, style=style)
 
 
 class View(NamedTuple):
-    camera: Camera
-    scene: Scene
+    look_at: np.ndarray
+    projection: np.ndarray
+    scene: tuple[Mesh]
     viewport: Viewport = Viewport()
+
+    @classmethod
+    def from_look_at_and_projection(
+        cls,
+        look_at: np.ndarray,
+        projection: np.ndarray,
+        scene: tuple[Mesh],
+        viewport: Viewport | None = None,
+    ):
+        assert look_at.shape == (4, 4) and projection.shape == (4, 4)
+        return cls(
+            look_at, projection, scene, viewport if viewport is not None else Viewport()
+        )
 
 
 class Engine:
     def __init__(self, views, precision=5):
-        self.views = views
-        self.precision = precision
+        self._views = views
+        self._precision = precision
 
-    def render(self, filename, size=(512, 512), viewBox="-0.5 -0.5 1.0 1.0", **extra):
-        drawing = svgwrite.Drawing(filename, size, viewBox=viewBox, **extra)
-        self.render_to_drawing(drawing)
+    @property
+    def views(self):
+        return self._views
+
+    @views.setter
+    def views(self, views):
+        self._views = views
+
+    @property
+    def precision(self):
+        return self._precision
+
+    def render(self, filename, size=(512, 512), viewbox="-0.5 -0.5 1.0 1.0", **extra):
+        drawing = svgwrite.Drawing(filename, size, viewBox=viewbox, **extra)
+        self._draw(drawing)
         drawing.save()
+        print(f"Wrote file {filename}")
 
-    def render_to_drawing(self, drawing):
+    def _draw(self, drawing):
         for view in self.views:
-            projection = np.dot(view.camera.view, view.camera.projection)
-
+            projection = np.dot(view.look_at, view.projection)
+            # Initialize clip path. See https://www.w3.org/TR/SVG11/masking.html#ClippingPaths
             clip_path = drawing.defs.add(drawing.clipPath())
             clip_min = view.viewport.minx, view.viewport.miny
             clip_size = view.viewport.width, view.viewport.height
             clip_path.add(drawing.rect(clip_min, clip_size))
 
-            for mesh in view.scene.meshes:
-                g = self._create_group(drawing, projection, view.viewport, mesh)
-                g["clip-path"] = clip_path.get_funciri()
-                drawing.add(g)
+            for mesh in view.scene:
+                group = self._create_group(drawing, projection, view.viewport, mesh)
+                group["clip-path"] = clip_path.get_funciri()
+                drawing.add(group)
 
     def _create_group(self, drawing, projection, viewport, mesh):
         faces = mesh.faces
@@ -86,13 +216,16 @@ class Engine:
 
         # Reject trivially clipped polygons.
         xyz, w = faces[:, :, :3], faces[:, :, 3:]
-        accepted = np.logical_and(np.greater(xyz, -w), np.less(xyz, +w))
-        accepted = np.all(accepted, 2)  # vert is accepted if xyz are all inside
-        accepted = np.any(accepted, 1)  # face is accepted if any vert is inside
-        degenerate = np.less_equal(w, 0)[:, :, 0]  # vert is bad if its w <= 0
-        degenerate = np.any(degenerate, 1)  # face is bad if any of its verts are bad
+        accepted = (xyz > -w) & (xyz < +w)
+        accepted = accepted.all(axis=2)  # vert is accepted if xyz are all inside
+        accepted = accepted.any(axis=1)  # face is accepted if any vert is inside
+        degenerate = (w <= 0)[:, :, 0]  # vert is bad if its w <= 0
+        degenerate = degenerate.any(axis=1)  # face is bad if any of its verts are bad
         accepted = np.logical_and(accepted, np.logical_not(degenerate))
+
         faces = np.compress(accepted, faces, axis=0)
+        if len(faces) == 0:
+            raise ValueError("All faces were pruned! Check your projection matrix.")
 
         # Apply perspective transformation.
         xyz, w = faces[:, :, :3], faces[:, :, 3:]
@@ -119,6 +252,7 @@ class Engine:
 
         # Create circles.
         if mesh.circle_radius > 0:
+            print("Drawing circles")
             for face_index, face in enumerate(faces):
                 style = shader(face_indices[face_index], 0)
                 if style is None:
@@ -134,11 +268,12 @@ class Engine:
             if style is None:
                 continue
             face = np.around(face[:, :2], self.precision)
+            _, indices = np.unique(face, return_index=True, axis=0)
+            face = face[sorted(indices)]
             if len(face) == 2:
                 group.add(drawing.line(face[0], face[1], **style))
             else:
                 group.add(drawing.polygon(face, **style))
-
         return group
 
     def _sort_back_to_front(self, faces):
@@ -147,6 +282,52 @@ class Engine:
             z_centroids[face_index] /= len(faces[face_index])
         return np.argsort(z_centroids)
 
+
+if __name__ == "__main__":
+    from coxeter.families import ArchimedeanFamily, PlatonicFamily
+
+    ArchimedeanFamily, PlatonicFamily
+
+    style = {
+        "fill": "yellow",
+        "fill_opacity": "0.75",
+        "stroke": "black",
+        "stroke_linejoin": "round",
+        "stroke_width": "0.005",
+    }
+
+    filename = "test.svg"
+    size = (512, 512)
+    min_x, min_y, width, height = -0.5, -0.5, 1.0, 1.0
+    view_box = np.asarray([min_x, min_y, width, height])
+
+    pos_object = [0, 0, 0]  # Shape centroid.  "at" in openGL terms
+    pos_camera = 20 * np.array([5, 4, 3])  # Camera position. "eye" in openGL terms
+    vec_up = [0, 0, 1]
+
+    z_near, z_far, fov_y = 100, 1000, 1.0
+
+    poly = ArchimedeanFamily.get_shape("Truncated Cube")
+    poly = PlatonicFamily.get_shape("Cube")
+    poly.volume = 1
+    poly.centroid = [0, 0, 0]
+
+    s2 = np.sqrt(2)
+    s3 = np.sqrt(3)
+
+    print(
+        "lookat\n", get_lookat_matrix(pos_object, pos_camera, vec_up=vec_up).round(12)
+    )
+
+    mesh = Mesh.from_poly(poly, style=style)
+    view = View.from_look_at_and_projection(
+        look_at=get_lookat_matrix(pos_object, pos_camera, vec_up=vec_up),
+        projection=get_projection_matrix(z_near=z_near, z_far=z_far, fov_y=fov_y),
+        # projection=np.array([[2,0,0,0],[0,2,0,0],[0,0,-2,0],[-1,-1,-1,1]]),
+        scene=[mesh],
+    )
+
+    Engine([view]).render(filename)
 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/svg3d.py
+++ b/svg3d.py
@@ -167,6 +167,14 @@ class View(NamedTuple):
             look_at, projection, scene, viewport if viewport is not None else Viewport()
         )
 
+    @classmethod
+    def isometric(cls, scene, fov: float = 1.0):
+        return cls(
+            look_at=get_lookat_matrix(pos_object=[0, 0, 0], pos_camera=[100, 100, 100]),
+            projection=get_projection_matrix(z_near=1.0, z_far=200.0, fov_y=fov),
+            scene=scene,
+        )
+
 
 class Engine:
     def __init__(self, views, precision=5):

--- a/svg3d.py
+++ b/svg3d.py
@@ -308,52 +308,6 @@ class Engine:
         return np.argsort(z_centroids)
 
 
-if __name__ == "__main__":
-    from coxeter.families import ArchimedeanFamily, PlatonicFamily
-
-    ArchimedeanFamily, PlatonicFamily
-
-    style = {
-        "fill": "yellow",
-        "fill_opacity": "0.75",
-        "stroke": "black",
-        "stroke_linejoin": "round",
-        "stroke_width": "0.005",
-    }
-
-    filename = "test.svg"
-    size = (512, 512)
-    min_x, min_y, width, height = -0.5, -0.5, 1.0, 1.0
-    view_box = np.asarray([min_x, min_y, width, height])
-
-    pos_object = [0, 0, 0]  # Shape centroid.  "at" in openGL terms
-    pos_camera = 20 * np.array([5, 4, 3])  # Camera position. "eye" in openGL terms
-    vec_up = [0, 0, 1]
-
-    z_near, z_far, fov_y = 100, 1000, 1.0
-
-    poly = ArchimedeanFamily.get_shape("Truncated Cube")
-    poly = PlatonicFamily.get_shape("Cube")
-    poly.volume = 1
-    poly.centroid = [0, 0, 0]
-
-    s2 = np.sqrt(2)
-    s3 = np.sqrt(3)
-
-    print(
-        "lookat\n", get_lookat_matrix(pos_object, pos_camera, vec_up=vec_up).round(12)
-    )
-
-    mesh = Mesh.from_poly(poly, style=style)
-    view = View.from_look_at_and_projection(
-        look_at=get_lookat_matrix(pos_object, pos_camera, vec_up=vec_up),
-        projection=get_projection_matrix(z_near=z_near, z_far=z_far, fov_y=fov_y),
-        # projection=np.array([[2,0,0,0],[0,2,0,0],[0,0,-2,0],[-1,-1,-1,1]]),
-        scene=[mesh],
-    )
-
-    Engine([view]).render(filename)
-
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
## Description

```
Changed:
- Removed pyrr dependency by implementing matrix methods
- `Mesh` class now ingests a ConvexPolyhedron object. The `faces` property now draws data from that attribute. It can also be set manually
- Backwards-compatible initialization of Meshes can be achieved with the `Mesh.from_faces` classmethod

Added: 
- Added `isometric`, `dimetric`, and `trimetric` convenience functions to `View` class.
- Support multiple face geometries in `Mesh`. Faces are padded out to the largest polygon's size in the projection step, and are filtered back down before drawing the SVG.
- `get_lookat_matrix` and `get_projection_matrix` methods to replace calls to `pyrr` required by the old version

Removed:
- `Camera` class has been replaced with `view.look_at` and `view.projection`
- `Scene` class has been removed in favor of basic Python iterables.
```


There are some significant breaking changes made in this PR. As the original repo has not had changes in a few years, I will base further development off of this PR.