### PR TITLE
Add style to usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ In addition to convenience methods, `svg3d` allows full control over the viewpor
 
    # A "scene" is a list of Mesh objects, which can be easily generated from raw data
    scene = [
-       svg3d.Mesh.from_vertices_and_faces(vertices, faces, shader=empty_shader)
+       svg3d.Mesh.from_vertices_and_faces(vertices, faces, shader=empty_shader, style=style)
    ]
 
    view = svg3d.View.from_look_at_and_projection(


### PR DESCRIPTION
## Description
The usage example wasn't rendering correctly because the style attributes were not included in the group. This change corrects this.

## Motivation and Context
The generated SVG should match the usage example.

## Checklist:
- [x] The changes introduced by this pull request are covered by existing or newly introduced tests.
- [x] I have updated the [changelog](https://github.com/janbridley/svg3d/blob/main/changelog.md).


<!-- readthedocs-preview svg3d start -->
----
📚 Documentation preview 📚: https://svg3d--19.org.readthedocs.build/en/19/

<!-- readthedocs-preview svg3d end -->